### PR TITLE
Add AutoCollector Upgrade

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,59 +1,21 @@
 import "react-toastify/dist/ReactToastify.css";
-import { useRef, useState } from "react";
-import { toast } from "react-toastify";
+import { useRef } from "react";
 import { IRefPhaserGame, PhaserGame } from "./game/PhaserGame";
 import AuthContainer from "./components/Auth/AuthContainer";
 import { useDispatch, useSelector } from "react-redux";
-import { addBit, sellData } from "./slices/gameDataSlice";
+import { sellData } from "./slices/gameDataSlice";
 import BoxContainer from "./components/BoxContainer";
 import Box from "./components/Box";
-import { setGameData } from "./slices/gameDataSlice";
-import {
-  useSaveGameMutation,
-  useLoadGameMutation
-} from "./slices/gameDataSlice";
 import { IGameData } from "../../shared/types";
-import Profile from "./components/Auth/Profile";
 import UpgradesContainer from "./components/UpgradesContainer";
+import AutoCollector from "./components/AutoCollector";
 
 const App = () => {
   const gameData: IGameData = useSelector((state: any) => state.gameData);
-  const { userInfo } = useSelector((state: any) => state.auth);
-
   const dispatch = useDispatch();
 
   //  References to the PhaserGame component (game and scene are exposed)
   const phaserRef = useRef<IRefPhaserGame | null>(null);
-
-  const [saveGame, saveMutationStatus] = useSaveGameMutation();
-  const saveGameClicked = async (e) => {
-    e.preventDefault();
-
-    try {
-      const res = await saveGame(gameData).unwrap();
-      dispatch(setGameData(res));
-      toast.success("Saved successfully");
-    } catch (err) {
-      toast.error(err?.data?.message || err.error);
-    }
-  };
-
-  const [loadGame, loadMutationStatus] = useLoadGameMutation();
-  const loadGameClicked = async (e) => {
-    e.preventDefault();
-
-    try {
-      const loadData = {
-        _id: userInfo._id
-      };
-
-      const res = await loadGame(loadData).unwrap();
-      dispatch(setGameData(res));
-      toast.success("Loaded successfully");
-    } catch (err) {
-      toast.error(err?.data?.message || err.error);
-    }
-  };
 
   return (
     <>
@@ -66,10 +28,11 @@ const App = () => {
             <AuthContainer></AuthContainer>
           </Box>
           <Box smallIcon={"B"}>
-            <p>{`Numer of Bits: ${gameData.numBits}`}</p>
-            <p>{`Curency Amount: ${gameData.currencyAmount}`}</p>
+            <p>Numer of Bits: {gameData.numBits}</p>
+            <p>Curency Amount: {gameData.currencyAmount}</p>
             <UpgradesContainer></UpgradesContainer>
             <button onClick={() => dispatch(sellData())}>Sell Data</button>
+            <AutoCollector></AutoCollector>
           </Box>
         </BoxContainer>
       </div>

--- a/frontend/src/components/AutoCollector.tsx
+++ b/frontend/src/components/AutoCollector.tsx
@@ -1,0 +1,40 @@
+import { useDispatch, useSelector } from "react-redux";
+import { GameVariable, IGameData } from "../../../shared/types";
+import { calculateVariableValue } from "../../../shared/util";
+import { addBits } from "../slices/gameDataSlice";
+import { useEffect } from "react";
+
+const AutoCollector = () => {
+  const gameData: IGameData = useSelector((state: any) => state.gameData);
+  const autoBitAmount: number = calculateVariableValue(gameData.upgrades, GameVariable.AutoBitGatheringAmount);
+  const autoBitInterval: number = calculateVariableValue(gameData.upgrades, GameVariable.AutoBitGatheringInterval);
+
+  useEffect(() => {
+    if (!(autoBitAmount && autoBitInterval)) {
+      return;
+    }
+
+    const autoCollectRunner = setInterval(() => {
+      dispatch(addBits({ additionalBits: autoBitAmount }));
+    }, autoBitInterval);
+
+    return () => clearInterval(autoCollectRunner);
+  }, [autoBitAmount, autoBitInterval]);
+
+  if (!(autoBitAmount && autoBitInterval)) {
+    return <></>;
+  }
+
+  const dispatch = useDispatch();
+
+  return (
+    <div className="auto-collector">
+      <h2>🤖</h2>
+      <p>
+        You are currently collecting {autoBitAmount} bit(s) every {autoBitInterval} milliseconds.
+      </p>
+    </div>
+  );
+};
+
+export default AutoCollector;

--- a/frontend/src/slices/gameDataSlice.ts
+++ b/frontend/src/slices/gameDataSlice.ts
@@ -1,10 +1,8 @@
-
-
 import { createSlice } from "@reduxjs/toolkit";
 import { IGameData } from "../../../shared/types";
-import { apiSlice } from './apiSlice';
+import { apiSlice } from "./apiSlice";
 import { EventBus } from "../game/EventBus";
-const GAME_API_PATH = "/api/game-data"
+const GAME_API_PATH = "/api/game-data";
 
 const initialState: IGameData = {
   numBits: 0,
@@ -19,6 +17,9 @@ export const gameDataSlice = createSlice({
   reducers: {
     addBit: (state) => {
       state.numBits += 1;
+    },
+    addBits: (state, action) => {
+      state.numBits += action.payload.additionalBits;
     },
     sellData: (state) => {
       state.currencyAmount += state.numBits / 10.0;
@@ -43,24 +44,21 @@ export const gameDataApiSlice = apiSlice.injectEndpoints({
       query: (data) => ({
         credentials: "include",
         url: `${GAME_API_PATH}/save`,
-        method: 'POST',
-        body: data,
-      }),
+        method: "POST",
+        body: data
+      })
     }),
     loadGame: builder.mutation({
       query: () => ({
         credentials: "include",
         url: `${GAME_API_PATH}/load`,
-        method: 'GET',
-      }),
-    }),
-  }),
+        method: "GET"
+      })
+    })
+  })
 });
 
-export const {
-  useSaveGameMutation,
-  useLoadGameMutation
-} = gameDataApiSlice;
+export const { useSaveGameMutation, useLoadGameMutation } = gameDataApiSlice;
 
-export const { addBit, setGameData, sellData, purchaseUpgrade } = gameDataSlice.actions;
+export const { addBit, addBits, setGameData, sellData, purchaseUpgrade } = gameDataSlice.actions;
 export default gameDataSlice.reducer;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2,7 +2,7 @@ export enum GameVariable {
   BitCheckInterval,
   BitAppearanceProbability,
   AutoBitGatheringAmount,
-  AutoBitGatheringInterval,
+  AutoBitGatheringInterval
 }
 
 export enum VariableModFunction {
@@ -11,14 +11,18 @@ export enum VariableModFunction {
   Set
 }
 
+export interface IUpgradeEffect {
+  variableAffected: GameVariable;
+  variableMod: VariableModFunction;
+  modValue: number;
+}
+
 export interface IUpgrade {
   name: string;
   description: string;
   picture: string;
   cost: number;
-  variableAffected: GameVariable;
-  variableMod: VariableModFunction;
-  modValue: number
+  effects: IUpgradeEffect[];
 }
 
 export enum UpgradeStatus {

--- a/shared/upgrades.ts
+++ b/shared/upgrades.ts
@@ -6,28 +6,58 @@ export const starterUpgrades: IUpgrade[] = [
     description: "Once every second, look to see if there are any bits available for harvesting",
     picture: "🔍",
     cost: 0,
-    variableAffected: GameVariable.BitCheckInterval,
-    variableMod: VariableModFunction.Set,
-    modValue: 1000
+    effects: [
+      {
+        variableAffected: GameVariable.BitCheckInterval,
+        variableMod: VariableModFunction.Set,
+        modValue: 1000
+      }
+    ]
   },
   {
     name: "Chance for Bits",
     description: "When checking for bits, succeed in finding one 50% of the time",
     picture: "❇",
     cost: 0,
-    variableAffected: GameVariable.BitAppearanceProbability,
-    variableMod: VariableModFunction.Set,
-    modValue: .5
+    effects: [
+      {
+        variableAffected: GameVariable.BitAppearanceProbability,
+        variableMod: VariableModFunction.Set,
+        modValue: 0.5
+      }
+    ]
   },
   {
     name: "Double Checks",
     description: "Check for bits twice as often",
     picture: "🔍🔍",
     cost: 10,
-    variableAffected: GameVariable.BitCheckInterval,
-    variableMod: VariableModFunction.Multiply,
-    modValue: .5
+    effects: [
+      {
+        variableAffected: GameVariable.BitCheckInterval,
+        variableMod: VariableModFunction.Multiply,
+        modValue: 0.5
+      }
+    ]
   },
+  {
+    name: "Al the Auto-Collector",
+    description: "Hire an A.I. intern to collect bits for you",
+    picture: "🤖",
+    cost: 2,
+    effects: [
+      {
+        variableAffected: GameVariable.AutoBitGatheringAmount,
+        variableMod: VariableModFunction.Set,
+        modValue: 1
+      },
+      {
+        variableAffected: GameVariable.AutoBitGatheringInterval,
+        variableMod: VariableModFunction.Set,
+        modValue: 1000
+      }
+    ]
+  }
 ];
 
 export const allUpgrades: IUpgrade[] = starterUpgrades;


### PR DESCRIPTION
This pull request includes:

- A new upgrade in the starter upgrades
- A new way to store upgrade effects (now multiple effects are possible
- A reconfiguring of the effect calculation (Set always has to happen first)
- Some cleanup of the main App component
- The ability to dispatch an event that adds multiple bits instead of just one