### PR TITLE
Fix Render deployment error

### DIFF
--- a/frontend/src/components/DesktopApps/AppShortcut.tsx
+++ b/frontend/src/components/DesktopApps/AppShortcut.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { AppType } from "../../../../shared/types";
-import { Button } from "react-bootstrap";
-import { url } from "inspector";
 
 interface AppShortcutProps {
   appType: AppType;


### PR DESCRIPTION
This will remove two unused imports from the `AppShortcut` component. The `insepctor` import is the one causing the error but I removed the other unused import while I was there.