### PR TITLE
166 give viruses trapped at the bottom of the screen a vertical boost

### DIFF
--- a/frontend/src/game/scenes/Collect.ts
+++ b/frontend/src/game/scenes/Collect.ts
@@ -13,7 +13,7 @@ export class Collect extends Scene {
   screenCenterY: number;
   bitSweeperSize: number = 0;
   virusSpawnVar: number = 0.5;
-  virusMaxSpawn: number = 10;
+  virusMaxSpawn: number = 5;
   bitAppearEvent: any;
   accrewedTime: number = 0;
   changeTextTime: number = 500;

--- a/frontend/src/game/scenes/Collect.ts
+++ b/frontend/src/game/scenes/Collect.ts
@@ -13,7 +13,7 @@ export class Collect extends Scene {
   screenCenterY: number;
   bitSweeperSize: number = 0;
   virusSpawnVar: number = 0.5;
-  virusMaxSpawn: number = 5;
+  virusMaxSpawn: number = 10;
   bitAppearEvent: any;
   accrewedTime: number = 0;
   changeTextTime: number = 500;
@@ -123,6 +123,11 @@ export class Collect extends Scene {
       this.accrewedTime %= this.changeTextTime;
       for (const bit of this.bitGroup.getChildren() as Bit[]) {
         bit.changeText();
+      }
+      for (const virus of this.virusGroup.getChildren() as Virus[]) {
+        if (Math.abs(virus.body.velocity.y) < 100 && virus.y > this.cameras.main.height - 50) {
+          virus.setVelocityY(-500);
+        }
       }
     }
   }


### PR DESCRIPTION
Every 500ms the children of the `virusGroup` are given a vertical boost upwards if they are at the bottom of the screen and have a low velocity. A potential energy equation may be more suited though.