### PR TITLE
103 add upgrade for packet amount

### DIFF
--- a/frontend/src/game/Bit.ts
+++ b/frontend/src/game/Bit.ts
@@ -2,12 +2,13 @@ import { GameObjects } from "phaser";
 import { EventBus } from "./EventBus";
 import { Collect } from "./scenes/Collect";
 
+const startheight: number = 0;
+
 export default class Bit extends GameObjects.Text {
-  declare static scene: Collect;
+  static scene: Collect;
   static maxCharsetIndexValue = 1;
   static value = 1;
   charsetIndex: number;
-  startheight: number = 0;
 
   constructor(x: number, y: number) {
     super(Bit.scene, x, y, "1", {});
@@ -17,13 +18,12 @@ export default class Bit extends GameObjects.Text {
 
     this.setInteractive();
     this.on("pointerdown", () => {
-      EventBus.emit("add-bit");
-      this.collect();
+      this.collect(true);
     });
 
     Bit.scene.tweens.add({
       targets: this,
-      y: { from: this.startheight, to: this.startheight + 1000 },
+      y: { from: startheight, to: startheight + 1000 },
       duration: 10000,
       onComplete: () => {
         this.destroy();
@@ -42,12 +42,14 @@ export default class Bit extends GameObjects.Text {
     this.setText(charset[this.charsetIndex]);
   }
 
-  collect(spawnVirus = true) {
-    this.destroy();
-    EventBus.emit("add-bit");
+  collect(notSweeper = false, spawnVirus = true) {
+    if (notSweeper !== Bit.scene.sweeper.visible) {
+      EventBus.emit("add-bit");
+    }
     if (spawnVirus && Math.random() <= Bit.scene.virusSpawnVar) {
       Bit.scene.createVirus();
     }
+    this.destroy();
   }
 }
 

--- a/frontend/src/game/Bit.ts
+++ b/frontend/src/game/Bit.ts
@@ -4,10 +4,10 @@ import { Collect } from "./scenes/Collect";
 
 export default class Bit extends GameObjects.Text {
   declare static scene: Collect;
-  static charset: Array<string> = ["0", "1"];
-  charsetI: number;
+  static maxCharsetIndexValue = 1;
+  static value = 1;
+  charsetIndex: number;
   startheight: number = 0;
-  toDestroy: boolean = false;
 
   constructor(x: number, y: number) {
     super(Bit.scene, x, y, "1", {});
@@ -30,17 +30,16 @@ export default class Bit extends GameObjects.Text {
       }
     });
 
-    this.charsetI = Phaser.Math.Between(0, Bit.charset.length - 1);
+    this.charsetIndex = Phaser.Math.Between(0, Bit.maxCharsetIndexValue);
   }
 
   changeText() {
     let newIndex: number;
     do {
-      newIndex = Phaser.Math.Between(0, Bit.charset.length - 1);
-    } while (this.charsetI === newIndex);
-
-    this.charsetI = newIndex;
-    this.setText(Bit.charset[this.charsetI]);
+      newIndex = Phaser.Math.Between(0, Bit.maxCharsetIndexValue);
+    } while (this.charsetIndex === newIndex);
+    this.charsetIndex = newIndex;
+    this.setText(charset[this.charsetIndex]);
   }
 
   collect(spawnVirus = true) {
@@ -51,3 +50,70 @@ export default class Bit extends GameObjects.Text {
     }
   }
 }
+
+export const charset: string[] = [
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "I",
+  "J",
+  "K",
+  "L",
+  "M",
+  "N",
+  "O",
+  "P",
+  "Q",
+  "R",
+  "S",
+  "T",
+  "U",
+  "V",
+  "W",
+  "X",
+  "Y",
+  "Z",
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+  "i",
+  "j",
+  "k",
+  "l",
+  "m",
+  "n",
+  "o",
+  "p",
+  "q",
+  "r",
+  "s",
+  "t",
+  "u",
+  "v",
+  "w",
+  "x",
+  "y",
+  "z",
+  "+",
+  "/"
+];

--- a/frontend/src/game/PhaserGame.tsx
+++ b/frontend/src/game/PhaserGame.tsx
@@ -8,6 +8,7 @@ import { GameVariable } from "../../../shared/types";
 import { calculateVariableValue } from "../../../shared/util";
 import { resetGameData } from "../slices/gameDataSlice";
 import { IGameState } from "../store";
+import Bit from "./Bit";
 
 interface IProps {}
 
@@ -64,7 +65,7 @@ export const PhaserGame = forwardRef<IRefPhaserGame, IProps>(function PhaserGame
 
   useEffect(() => {
     EventBus.on("add-bit", () => {
-      dispatch(addBits(1));
+      dispatch(addBits(Bit.value));
     });
 
     return () => {

--- a/frontend/src/game/PhaserGame.tsx
+++ b/frontend/src/game/PhaserGame.tsx
@@ -65,6 +65,7 @@ export const PhaserGame = forwardRef<IRefPhaserGame, IProps>(function PhaserGame
 
   useEffect(() => {
     EventBus.on("add-bit", () => {
+      console.log(Bit.value);
       dispatch(addBits(Bit.value));
     });
 

--- a/frontend/src/game/scenes/Collect.ts
+++ b/frontend/src/game/scenes/Collect.ts
@@ -4,7 +4,6 @@ import { GameVariable, IUpgrade } from "../../../../shared/types";
 import { calculateVariableValue } from "../../../../shared/util";
 import Bit, { charset } from "../Bit";
 import Virus from "../Virus";
-import { Z_NO_FLUSH } from "zlib";
 
 export class Collect extends Scene {
   sweeper: Phaser.GameObjects.Rectangle;
@@ -85,7 +84,7 @@ export class Collect extends Scene {
       const bap = calculateVariableValue(upgrades, GameVariable.BitAppearanceProbability);
 
       Bit.value = calculateVariableValue(upgrades, GameVariable.BitClickValue);
-      Bit.maxCharsetIndexValue = Math.min(Bit.value * 2 - 1, charset.length - 1);
+      Bit.maxCharsetIndexValue = Math.min(Bit.value ** 2 - 1, charset.length - 1);
 
       if (this.bitAppearEvent) {
         this.time.removeEvent(this.bitAppearEvent);
@@ -102,6 +101,11 @@ export class Collect extends Scene {
 
     EventBus.on("collect-all", () => {
       this.collectAll();
+    });
+
+    EventBus.on("reset-bit", () => {
+      Bit.value = 1;
+      Bit.maxCharsetIndexValue = 1;
     });
 
     EventBus.emit("current-scene-ready", this);

--- a/frontend/src/slices/gameDataSlice.ts
+++ b/frontend/src/slices/gameDataSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { GameVariable, ImageType, IUpgrade, VariableModFunction } from "../../../shared/types";
 import apiSlice from "./apiSlice";
 import { EventBus } from "../game/EventBus";
-import { allUpgrades } from "../../../shared/upgrades";
+import { allUpgrades, starterUpgrades } from "../../../shared/upgrades";
 import { flatObjByProp, intersection } from "../../../shared/util";
 
 const GAME_API_PATH = "/api/game-data";
@@ -30,41 +30,7 @@ const initialState: IGameData = {
   totalNumBits: 0,
   currencyAmount: 0,
   userEmail: "",
-  ups: {
-    acquired: [
-      {
-        name: "Check for Bits",
-        description: "Once every second, look to see if there are any bits available for harvesting",
-        picture: { image: "🔍", type: ImageType.String },
-        cost: 0,
-        effects: [
-          {
-            variableAffected: GameVariable.BitCheckInterval,
-            variableMod: VariableModFunction.Set,
-            modValue: 1000
-          }
-        ],
-        preReqs: []
-      },
-      {
-        name: "Chance for Bits",
-        description: "When checking for bits, succeed in finding one 50% of the time",
-        picture: { image: "❇", type: ImageType.String },
-        cost: 0,
-        effects: [
-          {
-            variableAffected: GameVariable.BitAppearanceProbability,
-            variableMod: VariableModFunction.Set,
-            modValue: 0.5
-          }
-        ],
-        preReqs: []
-      }
-    ],
-    purchasable: [],
-    unavailable: [],
-    uncategorized: allUpgrades
-  },
+  ups: { acquired: starterUpgrades, purchasable: [], unavailable: [], uncategorized: allUpgrades },
   solvedPuzzles: [],
   trustySales: 0,
   shadySales: 0
@@ -98,18 +64,18 @@ const gameDataSlice = createSlice({
       const upgrade = action.payload;
       state.currencyAmount -= upgrade.cost;
       ups.acquired.push(upgrade);
-      let index = -1;
+      let upgradeIndex = -1;
       for (let i = 0; i < ups.purchasable.length; i++) {
         if (upgrade.name == ups.purchasable[i].name) {
-          index = i;
+          upgradeIndex = i;
           break;
         }
       }
-      if (index == -1) {
+      if (upgradeIndex == -1) {
         console.log(`ERR: could not find index of upgrade: ${upgrade.name}`);
         return;
       }
-      ups.purchasable.splice(index, 1);
+      ups.purchasable.splice(upgradeIndex, 1);
       const purchasableBuffer: IUpgrade[] = [];
       const acquiredPrereqs = [...flatObjByProp(ups.acquired, "name"), ...state.solvedPuzzles];
       for (let i = 0; i < ups.unavailable.length; i++) {

--- a/frontend/src/slices/gameDataSlice.ts
+++ b/frontend/src/slices/gameDataSlice.ts
@@ -127,7 +127,10 @@ const gameDataSlice = createSlice({
         }
       }
     },
-    resetGameData: (_state) => initialState
+    resetGameData: (_state) => {
+      EventBus.emit("reset-bit");
+      return initialState;
+    }
   }
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,6 +1,7 @@
 export enum GameVariable {
   BitCheckInterval,
   BitAppearanceProbability,
+  BitClickValue,
   AutoBitGatheringAmount,
   AutoBitGatheringInterval,
   BitSweeperSize,

--- a/shared/upgrades.tsx
+++ b/shared/upgrades.tsx
@@ -53,9 +53,9 @@ const packet: IUpgrade[] = [
   {
     name: "Crumb",
     preReqs: [],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 2 bits",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 2 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
@@ -67,9 +67,9 @@ const packet: IUpgrade[] = [
   {
     name: "Nibble",
     preReqs: ["Crumb"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 4 bits",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 4 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
@@ -81,9 +81,9 @@ const packet: IUpgrade[] = [
   {
     name: "Byte",
     preReqs: ["Nibble"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 8 bits",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 8 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
@@ -95,9 +95,9 @@ const packet: IUpgrade[] = [
   {
     name: "Word",
     preReqs: ["Byte"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 2 bytes",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 16 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
@@ -109,9 +109,9 @@ const packet: IUpgrade[] = [
   {
     name: "Double Word",
     preReqs: ["Word"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 4 bytes",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 32 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
@@ -123,23 +123,9 @@ const packet: IUpgrade[] = [
   {
     name: "Quad Word",
     preReqs: ["Double Word"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
-    effects: [
-      {
-        variableAffected: GameVariable.BitClickValue,
-        variableMod: VariableModFunction.Set,
-        modValue: 64
-      }
-    ]
-  },
-  {
-    name: "Quad Word",
-    preReqs: ["Quad Word"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 8 bytes",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 64 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
@@ -151,9 +137,9 @@ const packet: IUpgrade[] = [
   {
     name: "Kibibit",
     preReqs: ["Quad Word"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 128 bytes",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 1024 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
@@ -165,70 +151,56 @@ const packet: IUpgrade[] = [
   {
     name: "Sector",
     preReqs: ["Kibibit"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 4 kibibits",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 1024 * 4 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
         variableMod: VariableModFunction.Set,
-        modValue: 512 * 8
+        modValue: 1024 * 4
       }
     ]
   },
   {
     name: "Kibibyte",
     preReqs: ["Sector"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 8 kibibits",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 8192 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
         variableMod: VariableModFunction.Set,
-        modValue: 1024 * 8
+        modValue: 8192
       }
     ]
   },
   {
     name: "CD-ROM Sector",
     preReqs: ["Kibibyte"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 2 kibibytes",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 8192 * 2 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
         variableMod: VariableModFunction.Set,
-        modValue: 4096 * 8
+        modValue: 8192 * 2
       }
     ]
   },
   {
     name: "Page",
     preReqs: ["CD-ROM Sector"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
+    description: "Each bit collected is now worth 4 kibibytes",
+    picture: { image: "1️⃣", type: ImageType.String },
+    cost: 8192 * 4 * 10,
     effects: [
       {
         variableAffected: GameVariable.BitClickValue,
         variableMod: VariableModFunction.Set,
-        modValue: 4096 * 8
-      }
-    ]
-  },
-  {
-    name: "Sector",
-    preReqs: ["Page"],
-    description: "",
-    picture: { image: "1", type: ImageType.String },
-    cost: 10,
-    effects: [
-      {
-        variableAffected: GameVariable.BitClickValue,
-        variableMod: VariableModFunction.Set,
-        modValue: 512 * 8
+        modValue: 8192 * 4
       }
     ]
   }

--- a/shared/upgrades.tsx
+++ b/shared/upgrades.tsx
@@ -1,22 +1,38 @@
 import { PuzzleNames } from "../frontend/src/components/puzzles/PuzzleAppDirectory";
 import { GameVariable, VariableModFunction, IUpgrade, ImageType } from "./types";
 
-const other: IUpgrade[] = [
-  /*{
+export const starterUpgrades: IUpgrade[] = [
+  {
+    name: "Check for Bits",
+    description: "Once every second, look to see if there are any bits available for harvesting",
+    picture: { image: "🔍", type: ImageType.String },
+    cost: 0,
+    effects: [
+      {
+        variableAffected: GameVariable.BitCheckInterval,
+        variableMod: VariableModFunction.Set,
+        modValue: 1000
+      }
+    ],
+    preReqs: []
+  },
+  {
     name: "Chance for Bits",
-    preReqs: [],
     description: "When checking for bits, succeed in finding one 50% of the time",
     picture: { image: "❇", type: ImageType.String },
     cost: 0,
     effects: [
       {
-    
         variableAffected: GameVariable.BitAppearanceProbability,
         variableMod: VariableModFunction.Set,
         modValue: 0.5
       }
-    ]
-  },*/
+    ],
+    preReqs: []
+  }
+];
+
+const other: IUpgrade[] = [
   {
     name: "Bit Sweeper",
     preReqs: [],
@@ -28,6 +44,191 @@ const other: IUpgrade[] = [
         variableAffected: GameVariable.BitSweeperSize,
         variableMod: VariableModFunction.Set,
         modValue: 30
+      }
+    ]
+  }
+];
+
+const packet: IUpgrade[] = [
+  {
+    name: "Crumb",
+    preReqs: [],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 2
+      }
+    ]
+  },
+  {
+    name: "Nibble",
+    preReqs: ["Crumb"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 4
+      }
+    ]
+  },
+  {
+    name: "Byte",
+    preReqs: ["Nibble"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 8
+      }
+    ]
+  },
+  {
+    name: "Word",
+    preReqs: ["Byte"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 16
+      }
+    ]
+  },
+  {
+    name: "Double Word",
+    preReqs: ["Word"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 32
+      }
+    ]
+  },
+  {
+    name: "Quad Word",
+    preReqs: ["Double Word"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 64
+      }
+    ]
+  },
+  {
+    name: "Quad Word",
+    preReqs: ["Quad Word"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 64
+      }
+    ]
+  },
+  {
+    name: "Kibibit",
+    preReqs: ["Quad Word"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 1024
+      }
+    ]
+  },
+  {
+    name: "Sector",
+    preReqs: ["Kibibit"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 512 * 8
+      }
+    ]
+  },
+  {
+    name: "Kibibyte",
+    preReqs: ["Sector"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 1024 * 8
+      }
+    ]
+  },
+  {
+    name: "CD-ROM Sector",
+    preReqs: ["Kibibyte"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 4096 * 8
+      }
+    ]
+  },
+  {
+    name: "Page",
+    preReqs: ["CD-ROM Sector"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 4096 * 8
+      }
+    ]
+  },
+  {
+    name: "Sector",
+    preReqs: ["Page"],
+    description: "",
+    picture: { image: "1", type: ImageType.String },
+    cost: 10,
+    effects: [
+      {
+        variableAffected: GameVariable.BitClickValue,
+        variableMod: VariableModFunction.Set,
+        modValue: 512 * 8
       }
     ]
   }
@@ -458,4 +659,4 @@ const checks: IUpgrade[] = [
   }
 ];
 
-export const allUpgrades: IUpgrade[] = [...checks, ...other, ...al, ...learn];
+export const allUpgrades: IUpgrade[] = [...checks, ...other, ...al, ...packet, ...learn];


### PR DESCRIPTION
Add upgrades that change how much each collected bit is worth, several small changes to variable names and upgrades, as well as adding additional characters the bits can show.
![image](https://github.com/user-attachments/assets/ae0e5621-7036-44f9-af25-0b9d6f2d01e1)
![image](https://github.com/user-attachments/assets/a0f89d40-f4cd-4b92-8c3d-6b660cb616f2)
