### PR TITLE
208 refresh purchasable upgrades every time the upgrades app is opened

### DIFF
--- a/frontend/src/components/desktop_apps/screens/UpgradeAppScreen.tsx
+++ b/frontend/src/components/desktop_apps/screens/UpgradeAppScreen.tsx
@@ -12,12 +12,12 @@ export default function UpgradeAppScreen() {
     dispatch(categorizeUpgrades());
   }
 
-  const trustySelling = () => {
+  const trustySelling = (): void => {
     dispatch(sellData(true));
     playSoundEffect("trustworthy");
   };
 
-  const shadySelling = () => {
+  const shadySelling = (): void => {
     dispatch(sellData(false));
     playSoundEffect("shady");
   };

--- a/frontend/src/components/puzzles/Puzzle.tsx
+++ b/frontend/src/components/puzzles/Puzzle.tsx
@@ -25,7 +25,7 @@ export default function Puzzle({ index, puzzle }: IPuzzleProps) {
   const [puzzleSolvedText, setPuzzleSolvedText] = useState<string>("");
   const dispatch = useDispatch();
 
-  const checkIfPuzzleComplete = () => {
+  const checkIfPuzzleComplete = (): void => {
     for (const answer of playerAnswers) {
       if (!answer.isSolved) {
         return;
@@ -74,7 +74,7 @@ export default function Puzzle({ index, puzzle }: IPuzzleProps) {
             checkIfPuzzleComplete();
           }}
         >
-          {" Check "}
+          Check
         </Button>
         <p></p>
         <span>{playerAnswers[i].resultText}</span>

--- a/frontend/src/components/puzzles/PuzzleContainer.tsx
+++ b/frontend/src/components/puzzles/PuzzleContainer.tsx
@@ -1,6 +1,5 @@
 import { useState, ReactNode } from "react";
 import { IPuzzle } from "./PuzzleAppDirectory";
-import { PuzzleSolvedStatus } from "../../../../shared/types";
 import { useSelector } from "react-redux";
 import { IGameState } from "../../store";
 import { IGameData } from "../../slices/gameDataSlice";
@@ -12,15 +11,12 @@ interface IPuzzleContainerProps {
 }
 
 export default function PuzzleContainer({ titleElements, puzzles }: IPuzzleContainerProps) {
-  let node: ReactNode = undefined;
   const gameData: IGameData = useSelector((state: IGameState) => state.gameData);
   const [visiblePuzzle, setVisiblePuzzle] = useState(-1);
 
-  const getPuzStatus = (checkedPuz: number): PuzzleSolvedStatus => {
-    if (gameData.solvedPuzzles.includes(puzzles[checkedPuz].name)) {
-      return PuzzleSolvedStatus.solved;
-    }
-    return PuzzleSolvedStatus.unsolved;
+  let node: ReactNode = undefined;
+  const getPuzStatus = (checkedPuz: number): string => {
+    return gameData.solvedPuzzles.includes(puzzles[checkedPuz].name) ? "solved" : "unsolved";
   };
 
   if (visiblePuzzle === -1) {
@@ -33,7 +29,7 @@ export default function PuzzleContainer({ titleElements, puzzles }: IPuzzleConta
           onClick={() => setVisiblePuzzle(i)}
           style={{ fontSize: "18px", width: "40%", height: "8%", borderWidth: "3px", marginBottom: "1%" }}
         >
-          Puzzle {i + 1}: {currPuzName} {getPuzStatus(i)}
+          {`Puzzle ${i + 1}: ${currPuzName} (${getPuzStatus(i)})`}
         </button>
       );
     }

--- a/frontend/src/slices/gameDataSlice.ts
+++ b/frontend/src/slices/gameDataSlice.ts
@@ -4,7 +4,6 @@ import apiSlice from "./apiSlice";
 import { EventBus } from "../game/EventBus";
 import { allUpgrades } from "../../../shared/upgrades";
 import { flatObjByProp, intersection } from "../../../shared/util";
-import { useDispatch } from "react-redux";
 
 const GAME_API_PATH = "/api/game-data";
 


### PR DESCRIPTION
Fixed the bug by creating the `categorizeUnavailableUpgrades` function in `gameDatSlice` and calling it within the `puzzleSolve` and `purchaseUpgrade` reducers.