### PR TITLE
fix: Rem multiple displays

### DIFF
--- a/frontend/src/AutoHack.tsx
+++ b/frontend/src/AutoHack.tsx
@@ -4,9 +4,12 @@ import Desktop from "./components/desktop_apps/Desktop";
 import Taskbar from "./components/desktop_apps/Taskbar";
 import HorizontalBar from "./components/desktop_apps/screens/HorizontalBar";
 import VerticalBar from "./components/desktop_apps/screens/VerticalBar";
+import { AppType } from "../../shared/types";
+import React from "react";
 
 export default function AutoHack() {
   const [startShown, setStartShown] = useState<boolean>(true);
+  const [openWindow, setOpenWindow] = React.useState<AppType>(null);
 
   if (startShown === true) {
     return <StartScreen setStartShown={setStartShown}></StartScreen>;
@@ -18,10 +21,10 @@ export default function AutoHack() {
       <div id="auto-hack" style={{ display: "flex", flex: "96%", flexDirection: "column" }}>
         <HorizontalBar></HorizontalBar>
         <div style={{ flex: "95%" }}>
-          <Desktop></Desktop>
+          <Desktop openWindow={openWindow} setOpenWindow={setOpenWindow}></Desktop>
         </div>
         <div style={{ flex: "5%" }}>
-          <Taskbar></Taskbar>
+          <Taskbar setOpenWindow={setOpenWindow}></Taskbar>
         </div>
         <HorizontalBar></HorizontalBar>
       </div>

--- a/frontend/src/components/desktop_apps/Desktop.tsx
+++ b/frontend/src/components/desktop_apps/Desktop.tsx
@@ -7,11 +7,16 @@ import { IGameState } from "../../store";
 import { IGameData } from "../../slices/gameDataSlice";
 import { PuzzleAppDirectory } from "../puzzles/PuzzleAppDirectory";
 
-export default function Desktop() {
-  const [openWindow, setOpenWindow] = React.useState(null as AppType | null);
+interface DesktopProps {
+  openWindow: AppType;
+  setOpenWindow: React.Dispatch<React.SetStateAction<AppType>>;
+}
+
+export default function Desktop({ openWindow, setOpenWindow }: DesktopProps) {
   const gameData: IGameData = useSelector((state: IGameState) => state.gameData);
-  const display = openWindow === null ? null : <AppWindow open={openWindow} setOpen={setOpenWindow}></AppWindow>;
   const desktopColor = useSelector((state: IGameState) => state.styleData.backgroundColor.desktop);
+
+  const display = openWindow === null ? null : <AppWindow open={openWindow} setOpen={setOpenWindow}></AppWindow>;
 
   let terminalVis = true;
   for (let i = 0; i < PuzzleAppDirectory.puzzleSets[1].puzzles.length; i++) {
@@ -34,6 +39,7 @@ export default function Desktop() {
         backgroundPosition: "top"
       }}
     >
+      {/* audio is in as a placeholder for Leo's song */}
       {/* <audio src="./../../../public/assets/audio/music/Virus Attack !!.wav" autoPlay loop></audio> */}
       <div style={{ padding: "20px", display: "flex", gap: "20px", flexWrap: "wrap" }}>
         <AppShortcut appType={AppType.Collector} setOpen={setOpenWindow}></AppShortcut>
@@ -41,13 +47,8 @@ export default function Desktop() {
         <AppShortcut appType={AppType.Puzzle} setOpen={setOpenWindow}></AppShortcut>
         <AppShortcut appType={AppType.Terminal} setOpen={setOpenWindow} visible={terminalVis}></AppShortcut>
         <AppShortcut appType={AppType.Learn} setOpen={setOpenWindow}></AppShortcut>
-        {/* <AppShortcut appType={AppType.Help} setOpen={setOpenWindow}></AppShortcut> */}
-        {/* <AppShortcut appType={AppType.Store} setOpen={setOpenWindow}></AppShortcut> */}
-        {/* {<AppShortcut appType={AppType.Login} setOpen={setOpenWindow}></AppShortcut>} */}
-        {/* <AppShortcut appType={AppType.Settings} setOpen={setOpenWindow}></AppShortcut> */}
       </div>
       {display}
     </div>
-    //audio is in as a placeholder for Leo's song
   );
 }

--- a/frontend/src/components/desktop_apps/Taskbar.tsx
+++ b/frontend/src/components/desktop_apps/Taskbar.tsx
@@ -7,13 +7,16 @@ import AppShortcut from "./AppShortcut";
 import { IGameState } from "../../store";
 import { IGameData } from "../../slices/gameDataSlice";
 
-const Taskbar: React.FC = () => {
-  const [openWindow, setOpenWindow] = React.useState(null as AppType | null);
-  const display = openWindow === null ? null : <AppWindow open={openWindow} setOpen={setOpenWindow}></AppWindow>;
-  const gameData: IGameData = useSelector((state: any) => state.gameData);
+interface TaskbarProps {
+  setOpenWindow: React.Dispatch<React.SetStateAction<AppType>>;
+}
+
+export default function Taskbar({ setOpenWindow }: TaskbarProps) {
+  const gameData = useSelector((state: IGameState) => state.gameData);
   const userInfo = useSelector((state: IGameState) => state.auth.userInfo);
   const taskBarColor = useSelector((state: IGameState) => state.styleData.backgroundColor.taskbar);
   const taskBarTextColor = useSelector((state: IGameState) => state.styleData.textColor.taskbar);
+
   return (
     <div
       id="taskbar"
@@ -39,7 +42,6 @@ const Taskbar: React.FC = () => {
           {userInfo !== null && `Hi, ${userInfo.name}!`}
         </p>
       </div>
-      <div>{display}</div>
       <p id="appText" style={{ textAlign: "center", marginRight: "34%", marginLeft: "34%", width: "200%" }}>
         Bits: {gameData.numBits}
         <br></br>PixelPayout: {Number(gameData.currencyAmount.toFixed(1))}
@@ -55,6 +57,4 @@ const Taskbar: React.FC = () => {
       </div>
     </div>
   );
-};
-
-export default Taskbar;
+}

--- a/frontend/src/components/desktop_apps/screens/UpgradeAppScreen.tsx
+++ b/frontend/src/components/desktop_apps/screens/UpgradeAppScreen.tsx
@@ -5,9 +5,10 @@ import { IGameState } from "../../../store";
 import { playSoundEffect } from "../../../soundEffect";
 
 export default function UpgradeAppScreen() {
+  const gameData: IGameData = useSelector((state: IGameState) => state.gameData);
+
   const dispatch = useDispatch();
 
-  const gameData: IGameData = useSelector((state: IGameState) => state.gameData);
   if (gameData.ups.uncategorized.length > 0) {
     dispatch(categorizeUpgrades());
   }


### PR DESCRIPTION
Fixes the bug mentioned by putting `openWindow` and `setOpenWindow` into `AutoHack.tsx`, passing them as props into `Desktop` and `Taskbar`, and then only rendering the window in `Desktop`.